### PR TITLE
Add the scraped page archive gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 # Find out more: https://morph.io/documentation/ruby
 
 source "https://rubygems.org"
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby "2.0.0"
 
@@ -12,3 +13,4 @@ gem "pry"
 gem "colorize"
 gem "nokogiri"
 gem "open-uri-cached"
+gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/everypolitician/scraped_page_archive.git
+  revision: 317f10cf3c6abbfb7f1871e80c73b8d8cf07f07a
+  specs:
+    scraped_page_archive (0.4.1)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -10,9 +18,14 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
     coderay (1.1.0)
     colorize (0.7.7)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     execjs (2.5.2)
+    git (1.3.0)
+    hashdiff (0.3.0)
     httpclient (2.6.0.1)
     method_source (0.8.2)
     mini_portile (0.6.2)
@@ -23,10 +36,19 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    safe_yaml (1.0.4)
     slop (3.6.0)
     sqlite3 (1.3.10)
     sqlite_magic (0.0.3)
       sqlite3
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -37,4 +59,11 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
+  scraped_page_archive!
   scraperwiki!
+
+RUBY VERSION
+   ruby 2.0.0p648
+
+BUNDLED WITH
+   1.13.2

--- a/scraper.rb
+++ b/scraper.rb
@@ -7,8 +7,9 @@ require 'csv'
 require 'scraperwiki'
 require 'pry'
 
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 def noko_for(url)
   Nokogiri::HTML(open(url).read) 


### PR DESCRIPTION
This PR adds the scraped page archive to the scraper.
## Notes to reviewer:

Since the db had to be deleted before moving the scraper, the scraper was moved in morph to EP-scrapers and the env. variable was set.
## Notes to merger:

merge before #1
